### PR TITLE
Travis CI: Upgrade to Python 3.7 and run py_versions_and_distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ group: travis_latest
 dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
 sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 language: python
-
-
-python:
- - 3.7
+python: 3.7
 
 install:
  - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
  - pip install flake8
  - pip install -r requirements.txt
 
-before-script:
+before_script:
  # Static analysis
  - flake8 --statistics --show-source --count .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
  - flake8 --statistics --show-source --count .
 
 script:
- - python3 -m py_versions_and_distros
+ - travis_wait 60 python3 -m py_versions_and_distros
 
 matrix:
  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
  - flake8 --statistics --show-source --count .
 
 script:
- - travis_wait 60 time python3 -m py_versions_and_distros
+ - travis_wait 65 time python3 -m py_versions_and_distros
 
 matrix:
  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
  - travis_wait 65 time python3 -m py_versions_and_distros
 
 matrix:
- fast_finish: true
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
+group: travis_latest
+dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 language: python
 
-python:
- - 3.6
 
-sudo: false
+python:
+ - 3.7
 
 install:
  - pip install flake8
  - pip install -r requirements.txt
 
-script:
+before-script:
  # Static analysis
- - flake8 --statistics --count .
+ - flake8 --statistics --show-source --count .
+
+script:
+ - python3 -m py_versions_and_distros
 
 matrix:
-  fast_finish: true
+ fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
  - flake8 --statistics --show-source --count .
 
 script:
- - travis_wait 60 python3 -m py_versions_and_distros
+ - travis_wait 60 time python3 -m py_versions_and_distros
 
 matrix:
  fast_finish: true


### PR DESCRIPTION
```
402 distros with Python 3.4+
============================
110 distros with Python 3.4
164 distros with Python 3.5
116 distros with Python 3.6
 12 distros with Python 3.7
```