### PR TITLE
README.rst: Added atricle from Python Language Summit 2018

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,4 +235,4 @@ Things I will not do
 Linux distributions and Python 2 topic at the Python Language Summit 2018
 =========================================================================
 
-https://lwn.net/Articles/756628/
+https://lwn.net/Articles/756628

--- a/README.rst
+++ b/README.rst
@@ -235,4 +235,4 @@ Things I will not do
 Linux distributions and Python 2 topic at the Python Language Summit 2018
 =========================================================================
 
-https://lwn.net/Articles/756628
+https://lwn.net/Articles/756628 

--- a/README.rst
+++ b/README.rst
@@ -231,3 +231,8 @@ Things I will not do
 - Make this script backward compatible with Python < 3.6
 
 - PEP 8 compliance
+
+Linux distributions and Python 2 topic at the Python Language Summit 2018
+=========================================================================
+
+https://lwn.net/Articles/756628/


### PR DESCRIPTION
With __456__ days until Python 2 end of life, today's stats are:
```
408 distros with Python 3.4+
============================
105 distros with Python 3.4
160 distros with Python 3.5
122 distros with Python 3.6
 21 distros with Python 3.7

501 distros with Python 2
===========================
  7 distros with Python 2.5
 53 distros with Python 2.6
441 distros with Python 2.7
```