### PR TITLE
DO NOT MERGE: How many repos ship Python 2,5, 2.6, and 2.7? 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 script:
  # Static analysis
  - flake8 --statistics --count .
+ - travis_wait 65 time python3 -m py_versions_and_distros
 
 matrix:
   fast_finish: true

--- a/py_versions_and_distros.py
+++ b/py_versions_and_distros.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 CSV_FIELDNAMES = ['distribution', 'dist_version', 'python_version', 'resource']
 PY_VER_MAP = {py_ver: [f'{py_ver}.{j}' for j in range(15)]
-              for py_ver in ('3.4', '3.5', '3.6', '3.7')
+              for py_ver in ('2.5', '2.6', '2.7')
               }
 DEBUG = False
 USER_AGENT = ('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 '


### PR DESCRIPTION
```
501 distros with Python 2
===========================
  7 distros with Python 2.5
 53 distros with Python 2.6
441 distros with Python 2.7
```